### PR TITLE
Handle odd sized returns

### DIFF
--- a/obd/protocols/protocol_can.py
+++ b/obd/protocols/protocol_can.py
@@ -64,6 +64,11 @@ class CANProtocol(Protocol):
         if self.id_bits == 11:
             raw = "00000" + raw
 
+        # Handle odd size frames and drop
+        if len(raw) > 16 and len(raw) & 1:
+            debug("Dropping frame for being wrong size (odd)")
+            return False
+    
         raw_bytes = bytearray(unhexlify(raw))
 
         # check for valid size


### PR DESCRIPTION
I've noticed many invalid returns from can of size 19 when padded with the additional 5 zeros. This crashes the watcher thread. This will handle them as unhexlify dumps