### PR TITLE
Add optional argument to set message headers and accept long messages.

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -103,7 +103,7 @@ class ELM327:
 
 
 
-    def __init__(self, portname, baudrate, protocol):
+    def __init__(self, portname, baudrate, protocol, headers):
         """Initializes port by resetting device and gettings supported PIDs. """
 
         logger.info("Initializing ELM327: PORT=%s BAUD=%s PROTOCOL=%s" %
@@ -163,6 +163,13 @@ class ELM327:
         if not self.__isok(r):
             self.__error("ATL0 did not return 'OK'")
             return
+
+        # ------------------------ set headers --------------------------------
+        if headers is not None:
+            r = self.__send(b"ATSH%X"%headers)
+            if not self.__isok(r):
+                self.__error("ATSH did not return 'OK'")
+                return
 
         # by now, we've successfuly communicated with the ELM, but not the car
         self.__status = OBDStatus.ELM_CONNECTED

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -48,7 +48,7 @@ class OBD(object):
         with it's assorted commands/sensors.
     """
 
-    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True, headers=None):
+    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True, headers=None, allow_long_messages = False):
         self.interface = None
         self.supported_commands = set(commands.base_commands())
         self.fast = fast # global switch for disabling optimizations
@@ -56,12 +56,12 @@ class OBD(object):
         self.__frame_counts = {} # keeps track of the number of return frames for each command
 
         logger.info("======================= python-OBD (v%s) =======================" % __version__)
-        self.__connect(portstr, baudrate, protocol, headers) # initialize by connecting and loading sensors
+        self.__connect(portstr, baudrate, protocol, headers, allow_long_messages) # initialize by connecting and loading sensors
         self.__load_commands()            # try to load the car's supported commands
         logger.info("===================================================================")
 
 
-    def __connect(self, portstr, baudrate, protocol, headers):
+    def __connect(self, portstr, baudrate, protocol, headers, allow_long_messages):
         """
             Attempts to instantiate an ELM327 connection object.
         """
@@ -77,13 +77,13 @@ class OBD(object):
 
             for port in portnames:
                 logger.info("Attempting to use port: " + str(port))
-                self.interface = ELM327(port, baudrate, protocol, headers)
+                self.interface = ELM327(port, baudrate, protocol, headers, allow_long_messages)
 
                 if self.interface.status() >= OBDStatus.ELM_CONNECTED:
                     break # success! stop searching for serial
         else:
             logger.info("Explicit port defined")
-            self.interface = ELM327(portstr, baudrate, protocol, headers)
+            self.interface = ELM327(portstr, baudrate, protocol, headers, allow_long_messages)
 
         # if the connection failed, close it
         if self.interface.status() == OBDStatus.NOT_CONNECTED:

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -48,7 +48,7 @@ class OBD(object):
         with it's assorted commands/sensors.
     """
 
-    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True):
+    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True, headers=None):
         self.interface = None
         self.supported_commands = set(commands.base_commands())
         self.fast = fast # global switch for disabling optimizations
@@ -56,12 +56,12 @@ class OBD(object):
         self.__frame_counts = {} # keeps track of the number of return frames for each command
 
         logger.info("======================= python-OBD (v%s) =======================" % __version__)
-        self.__connect(portstr, baudrate, protocol) # initialize by connecting and loading sensors
+        self.__connect(portstr, baudrate, protocol, headers) # initialize by connecting and loading sensors
         self.__load_commands()            # try to load the car's supported commands
         logger.info("===================================================================")
 
 
-    def __connect(self, portstr, baudrate, protocol):
+    def __connect(self, portstr, baudrate, protocol, headers):
         """
             Attempts to instantiate an ELM327 connection object.
         """
@@ -77,13 +77,13 @@ class OBD(object):
 
             for port in portnames:
                 logger.info("Attempting to use port: " + str(port))
-                self.interface = ELM327(port, baudrate, protocol)
+                self.interface = ELM327(port, baudrate, protocol, headers)
 
                 if self.interface.status() >= OBDStatus.ELM_CONNECTED:
                     break # success! stop searching for serial
         else:
             logger.info("Explicit port defined")
-            self.interface = ELM327(portstr, baudrate, protocol)
+            self.interface = ELM327(portstr, baudrate, protocol, headers)
 
         # if the connection failed, close it
         if self.interface.status() == OBDStatus.NOT_CONNECTED:

--- a/obd/protocols/protocol_legacy.py
+++ b/obd/protocols/protocol_legacy.py
@@ -181,33 +181,33 @@ class LegacyProtocol(Protocol):
 class SAE_J1850_PWM(LegacyProtocol):
     ELM_NAME = "SAE J1850 PWM"
     ELM_ID = "1"
-    def __init__(self, lines_0100, allow_long_messages):
+    def __init__(self, lines_0100, allow_long_messages = False):
         LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class SAE_J1850_VPW(LegacyProtocol):
     ELM_NAME = "SAE J1850 VPW"
     ELM_ID = "2"
-    def __init__(self, lines_0100, allow_long_messages):
+    def __init__(self, lines_0100, allow_long_messages = False):
         LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class ISO_9141_2(LegacyProtocol):
     ELM_NAME = "ISO 9141-2"
     ELM_ID = "3"
-    def __init__(self, lines_0100, allow_long_messages):
+    def __init__(self, lines_0100, allow_long_messages = False):
         LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class ISO_14230_4_5baud(LegacyProtocol):
     ELM_NAME = "ISO 14230-4 (KWP 5BAUD)"
     ELM_ID = "4"
-    def __init__(self, lines_0100, allow_long_messages):
+    def __init__(self, lines_0100, allow_long_messages = False):
         LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class ISO_14230_4_fast(LegacyProtocol):
     ELM_NAME = "ISO 14230-4 (KWP FAST)"
     ELM_ID = "5"
-    def __init__(self, lines_0100, allow_long_messages):
+    def __init__(self, lines_0100, allow_long_messages = False):
         LegacyProtocol.__init__(self, lines_0100, allow_long_messages)

--- a/obd/protocols/protocol_legacy.py
+++ b/obd/protocols/protocol_legacy.py
@@ -44,8 +44,9 @@ class LegacyProtocol(Protocol):
     TX_ID_ENGINE = 0x10
 
 
-    def __init__(self, lines_0100):
+    def __init__(self, lines_0100, allow_long_messages):
         Protocol.__init__(self, lines_0100)
+        self.__allow_long_messages = allow_long_messages
 
 
     def parse_frame(self, frame):
@@ -63,7 +64,7 @@ class LegacyProtocol(Protocol):
             logger.debug("Dropped frame for being too short")
             return False
 
-        if len(raw_bytes) > 11:
+        if len(raw_bytes) > 11 and not self.__allow_long_messages:
             logger.debug("Dropped frame for being too long")
             return False
 
@@ -180,33 +181,33 @@ class LegacyProtocol(Protocol):
 class SAE_J1850_PWM(LegacyProtocol):
     ELM_NAME = "SAE J1850 PWM"
     ELM_ID = "1"
-    def __init__(self, lines_0100):
-        LegacyProtocol.__init__(self, lines_0100)
+    def __init__(self, lines_0100, allow_long_messages):
+        LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class SAE_J1850_VPW(LegacyProtocol):
     ELM_NAME = "SAE J1850 VPW"
     ELM_ID = "2"
-    def __init__(self, lines_0100):
-        LegacyProtocol.__init__(self, lines_0100)
+    def __init__(self, lines_0100, allow_long_messages):
+        LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class ISO_9141_2(LegacyProtocol):
     ELM_NAME = "ISO 9141-2"
     ELM_ID = "3"
-    def __init__(self, lines_0100):
-        LegacyProtocol.__init__(self, lines_0100)
+    def __init__(self, lines_0100, allow_long_messages):
+        LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class ISO_14230_4_5baud(LegacyProtocol):
     ELM_NAME = "ISO 14230-4 (KWP 5BAUD)"
     ELM_ID = "4"
-    def __init__(self, lines_0100):
-        LegacyProtocol.__init__(self, lines_0100)
+    def __init__(self, lines_0100, allow_long_messages):
+        LegacyProtocol.__init__(self, lines_0100, allow_long_messages)
 
 
 class ISO_14230_4_fast(LegacyProtocol):
     ELM_NAME = "ISO 14230-4 (KWP FAST)"
     ELM_ID = "5"
-    def __init__(self, lines_0100):
-        LegacyProtocol.__init__(self, lines_0100)
+    def __init__(self, lines_0100, allow_long_messages):
+        LegacyProtocol.__init__(self, lines_0100, allow_long_messages)


### PR DESCRIPTION
Some vehicles require setting different message headers and send messages longer that 11 bytes.
Add optional arguments to set those headers and to accept long messages.