### PR TITLE
DIscover and print all information 

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -258,7 +258,7 @@ class ELM327:
     def set_baudrate(self, baud):
         if baud is None:
             # when connecting to pseudo terminal, don't bother with auto baud
-            if self.port_name().startswith("/dev/pts"):
+            if self.get_port_name().startswith("/dev/pts"):
                 logger.debug("Detected pseudo terminal, skipping baudrate setup")
                 return True
             else:
@@ -330,29 +330,36 @@ class ELM327:
         logger.error(str(msg))
 
 
-    def port_name(self):
+    def get_port_name(self):
         if self.__port is not None:
             return self.__port.portstr
         else:
             return ""
 
 
-    def status(self):
-        return self.__status
+    def get_port_baudrate(self):
+        if self.__port is not None:
+            return self.__port.baudrate
+        else:
+            return ""
 
 
-    def ecus(self):
-        return self.__protocol.ecu_map.values()
-
-
-    def protocol_name(self):
+    def get_protocol_name(self):
         return self.__protocol.ELM_NAME
 
 
-    def protocol_id(self):
+    def get_protocol_id(self):
         return self.__protocol.ELM_ID
 
 
+    def get_ecus(self):
+        return self.__protocol.ecu_map.values()
+
+
+    def status(self):
+        return self.__status
+    
+    
     def close(self):
         """
             Resets the device, and sets all

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -155,40 +155,46 @@ class OBD(object):
             return self.interface.status()
 
 
-    # not sure how useful this would be
-
-    # def ecus(self):
-    #     """ returns a list of ECUs in the vehicle """
-    #     if self.interface is None:
-    #         return []
-    #     else:
-    #         return self.interface.ecus()
+    def get_ecus(self):
+        """ returns a list of ECUs in the vehicle """
+        if self.interface is None:
+            return []
+        else:
+            return self.interface.get_ecus()
 
 
-    def protocol_name(self):
+    def get_protocol_name(self):
         """ returns the name of the protocol being used by the ELM327 """
         if self.interface is None:
             return ""
         else:
-            return self.interface.protocol_name()
+            return self.interface.get_protocol_name()
 
 
-    def protocol_id(self):
+    def get_protocol_id(self):
         """ returns the ID of the protocol being used by the ELM327 """
         if self.interface is None:
             return ""
         else:
-            return self.interface.protocol_id()
+            return self.interface.get_protocol_id()
 
 
-    def port_name(self):
+    def get_port_name(self):
         """ Returns the name of the currently connected port """
         if self.interface is not None:
-            return self.interface.port_name()
+            return self.interface.get_port_name()
         else:
             return ""
 
 
+    def get_port_baudrate(self):
+        """ Returns the speed of the currently connected port """
+        if self.interface is not None:
+            return str(self.interface.get_port_baudrate())
+        else:
+            return ""
+        
+        
     def is_connected(self):
         """
             Returns a boolean for whether a connection with the car was made.
@@ -214,6 +220,18 @@ class OBD(object):
             is supported by the car
         """
         return cmd in self.supported_commands
+    
+    
+    def get_supported_commands(self):
+        """
+            Returns a list of commands
+            supported by the car
+        """
+
+        if self.interface is not None:
+            return self.supported_commands
+        else:
+            return []
 
 
     def test_cmd(self, cmd, warn=True):
@@ -228,7 +246,7 @@ class OBD(object):
             return False
 
         # mode 06 is only implemented for the CAN protocols
-        if cmd.mode == 6 and self.interface.protocol_id() not in ["6", "7", "8", "9"]:
+        if cmd.mode == 6 and self.interface.get_protocol_id() not in ["6", "7", "8", "9"]:
             if warn:
                 logger.warning("Mode 06 commands are only supported over CAN protocols")
             return False

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -213,7 +213,23 @@ class OBD(object):
         for c in self.supported_commands:
             print(str(c))
 
+    def print_discovered(self):
+        """
+            Utility function meant to print all information discovered:
+            protocol, port name, port baudrate and all supported commands.
+        """
+        if self.interface is not None:
+            print ("The following information was used to connect to the ECU:")
+            print ("Protocole: " + self.get_protocol_name())
+            print ("Port name: " + self.get_port_name())
+            print ("Port rate: " + self.get_port_baudrate())
+            print ("The following commands are supported:")
 
+            for c in self.supported_commands:
+                print(str(c))
+        else:
+            print ("Impossible to print discovered information: no connection to the ECU.")
+            
     def supports(self, cmd):
         """
             Returns a boolean for whether the given command

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -219,11 +219,11 @@ class OBD(object):
             protocol, port name, port baudrate and all supported commands.
         """
         if self.interface is not None:
-            print ("The following information was used to connect to the ECU:")
+            print ("The following settings were used to connect to the ECU:")
             print ("Protocole: " + self.get_protocol_name())
             print ("Port name: " + self.get_port_name())
             print ("Port rate: " + self.get_port_baudrate())
-            print ("The following commands are supported:")
+            print ("The following OBD commands are supported:")
 
             for c in self.supported_commands:
                 print(str(c))

--- a/tests/test_OBD.py
+++ b/tests/test_OBD.py
@@ -23,7 +23,7 @@ class FakeELM:
         self._status = OBDStatus.CAR_CONNECTED
         self._last_command = None
 
-    def port_name(self):
+    def get_port_name(self):
         return self._portname
 
     def status(self):
@@ -32,10 +32,10 @@ class FakeELM:
     def ecus(self):
         return [ ECU.ENGINE, ECU.UNKNOWN ]
 
-    def protocol_name(self):
+    def get_protocol_name(self):
         return "ISO 15765-4 (CAN 11/500)"
 
-    def protocol_id(self):
+    def get_protocol_id(self):
         return "6"
 
     def close(self):
@@ -122,30 +122,30 @@ def test_port_name():
     """
     o = obd.OBD("/dev/null")
     o.interface = FakeELM("/dev/null")
-    assert o.port_name() == o.interface._portname
+    assert o.get_port_name() == o.interface.get_port_name()
 
     o.interface = FakeELM("A different port name")
-    assert o.port_name() == o.interface._portname
+    assert o.get_port_name() == o.interface.get_port_name()
 
 
 def test_protocol_name():
     o = obd.OBD("/dev/null")
 
     o.interface = None
-    assert o.protocol_name() == ""
+    assert o.get_protocol_name() == ""
 
     o.interface = FakeELM("/dev/null")
-    assert o.protocol_name() == o.interface.protocol_name()
+    assert o.get_protocol_name() == o.interface.get_protocol_name()
 
 
 def test_protocol_id():
     o = obd.OBD("/dev/null")
 
     o.interface = None
-    assert o.protocol_id() == ""
+    assert o.get_protocol_id() == ""
 
     o.interface = FakeELM("/dev/null")
-    assert o.protocol_id() == o.interface.protocol_id()
+    assert o.get_protocol_id() == o.interface.get_protocol_id()
 
 
 


### PR DESCRIPTION
This patch adds a print_discovered() clause which prints all detailed information about a connection.
It can simply be triggered using:
```
import obd
connection = obd.OBD()
connection.print_discovered()
```

It also modified some functions with the prefix "get_" for clarity and updates testing accordingly.

Feel free to modify, but we probably need some kind of utility to help and debug users.