### PR TITLE
Make connection timeout configurable

### DIFF
--- a/docs/Connections.md
+++ b/docs/Connections.md
@@ -20,7 +20,7 @@ connection = obd.OBD(ports[0]) # connect to the first port in the list
 
 <br>
 
-### OBD(portstr=None, baudrate=None, protocol=None, fast=True):
+### OBD(portstr=None, baudrate=None, protocol=None, fast=True, timeout=0.1):
 
 `portstr`: The UNIX device file or Windows COM Port for your adapter. The default value (`None`) will auto select a port.
 
@@ -34,6 +34,8 @@ connection = obd.OBD(ports[0]) # connect to the first port in the list
 - Appends a response limit to the end of the command, telling the adapter to return after it receives *N* responses (rather than waiting and eventually timing out). This feature can be enabled and disabled for individual commands.
 
 Disabling fast mode will guarantee that python-OBD outputs the unaltered command for every request.
+
+`timeout`: Specifies the connection timeout.
 
 <br>
 

--- a/obd/async.py
+++ b/obd/async.py
@@ -46,9 +46,9 @@ class Async(OBD):
     """
 
     def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
-                 conn_timeout=0.1):
+                 timeout=0.1):
         super(Async, self).__init__(portstr, baudrate, protocol, fast,
-                                    conn_timeout)
+                                    timeout)
         self.__commands    = {} # key = OBDCommand, value = Response
         self.__callbacks   = {} # key = OBDCommand, value = list of Functions
         self.__thread      = None

--- a/obd/async.py
+++ b/obd/async.py
@@ -45,8 +45,10 @@ class Async(OBD):
         Specialized for asynchronous value reporting.
     """
 
-    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True):
-        super(Async, self).__init__(portstr, baudrate, protocol, fast)
+    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
+                 conn_timeout=0.1):
+        super(Async, self).__init__(portstr, baudrate, protocol, fast,
+                                    conn_timeout)
         self.__commands    = {} # key = OBDCommand, value = Response
         self.__callbacks   = {} # key = OBDCommand, value = list of Functions
         self.__thread      = None

--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -103,7 +103,7 @@ class ELM327:
 
 
 
-    def __init__(self, portname, baudrate, protocol):
+    def __init__(self, portname, baudrate, protocol, conn_timeout):
         """Initializes port by resetting device and gettings supported PIDs. """
 
         logger.info("Initializing ELM327: PORT=%s BAUD=%s PROTOCOL=%s" %
@@ -116,6 +116,7 @@ class ELM327:
         self.__status   = OBDStatus.NOT_CONNECTED
         self.__port     = None
         self.__protocol = UnknownProtocol([])
+        self.conn_timeout = conn_timeout
 
 
         # ------------- open port -------------
@@ -276,7 +277,7 @@ class ELM327:
 
         # before we change the timout, save the "normal" value
         timeout = self.__port.timeout
-        self.__port.timeout = 0.1 # we're only talking with the ELM, so things should go quickly
+        self.__port.timeout = self.conn_timeout # we're only talking with the ELM, so things should go quickly
 
         for baud in self._TRY_BAUDS:
             self.__port.baudrate = baud

--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -103,7 +103,7 @@ class ELM327:
 
 
 
-    def __init__(self, portname, baudrate, protocol, conn_timeout):
+    def __init__(self, portname, baudrate, protocol, timeout):
         """Initializes port by resetting device and gettings supported PIDs. """
 
         logger.info("Initializing ELM327: PORT=%s BAUD=%s PROTOCOL=%s" %
@@ -116,7 +116,7 @@ class ELM327:
         self.__status   = OBDStatus.NOT_CONNECTED
         self.__port     = None
         self.__protocol = UnknownProtocol([])
-        self.conn_timeout = conn_timeout
+        self.timeout = timeout
 
 
         # ------------- open port -------------
@@ -277,7 +277,7 @@ class ELM327:
 
         # before we change the timout, save the "normal" value
         timeout = self.__port.timeout
-        self.__port.timeout = self.conn_timeout # we're only talking with the ELM, so things should go quickly
+        self.__port.timeout = self.timeout # we're only talking with the ELM, so things should go quickly
 
         for baud in self._TRY_BAUDS:
             self.__port.baudrate = baud

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -48,10 +48,12 @@ class OBD(object):
         with it's assorted commands/sensors.
     """
 
-    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True):
+    def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
+                 conn_timeout=0.1):
         self.interface = None
         self.supported_commands = set(commands.base_commands())
         self.fast = fast # global switch for disabling optimizations
+        self.conn_timeout = conn_timeout
         self.__last_command = b"" # used for running the previous command with a CR
         self.__frame_counts = {} # keeps track of the number of return frames for each command
 
@@ -77,13 +79,15 @@ class OBD(object):
 
             for port in portnames:
                 logger.info("Attempting to use port: " + str(port))
-                self.interface = ELM327(port, baudrate, protocol)
+                self.interface = ELM327(port, baudrate, protocol,
+                                        self.conn_timeout)
 
                 if self.interface.status() >= OBDStatus.ELM_CONNECTED:
                     break # success! stop searching for serial
         else:
             logger.info("Explicit port defined")
-            self.interface = ELM327(portstr, baudrate, protocol)
+            self.interface = ELM327(portstr, baudrate, protocol,
+                                    self.conn_timeout)
 
         # if the connection failed, close it
         if self.interface.status() == OBDStatus.NOT_CONNECTED:

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -49,11 +49,11 @@ class OBD(object):
     """
 
     def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
-                 conn_timeout=0.1):
+                 timeout=0.1):
         self.interface = None
         self.supported_commands = set(commands.base_commands())
         self.fast = fast # global switch for disabling optimizations
-        self.conn_timeout = conn_timeout
+        self.timeout = timeout
         self.__last_command = b"" # used for running the previous command with a CR
         self.__frame_counts = {} # keeps track of the number of return frames for each command
 
@@ -80,14 +80,14 @@ class OBD(object):
             for port in portnames:
                 logger.info("Attempting to use port: " + str(port))
                 self.interface = ELM327(port, baudrate, protocol,
-                                        self.conn_timeout)
+                                        self.timeout)
 
                 if self.interface.status() >= OBDStatus.ELM_CONNECTED:
                     break # success! stop searching for serial
         else:
             logger.info("Explicit port defined")
             self.interface = ELM327(portstr, baudrate, protocol,
-                                    self.conn_timeout)
+                                    self.timeout)
 
         # if the connection failed, close it
         if self.interface.status() == OBDStatus.NOT_CONNECTED:


### PR DESCRIPTION
Why:

* the hard-coded value of 0.1 was making it impossible to connect with
OSX, and possibly in other cases. -- https://github.com/brendan-w/python-OBD/issues/58

This change addresses the need by:

* Adding `conn_timeout` kwarg to OBD and Async, which defaults to 0.1,
but can be configured to suit the user's neeeds.

Other observations:

* There were a few failing tests locally (python3.6 on OSX 10.12.6) when
I cloned the repo, these tests are still failing.  I may look into these
next and submit another PR.