### PR TITLE
Changed line to use pyserial's "serial_for_url" instead of "Serial" for compatibility

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -120,7 +120,7 @@ class ELM327:
 
         # ------------- open port -------------
         try:
-            self.__port = serial.Serial(portname, \
+            self.__port = serial.serial_for_url(portname, \
                                         parity   = serial.PARITY_NONE, \
                                         stopbits = 1, \
                                         bytesize = 8,


### PR DESCRIPTION
Solves issue #107 by using pyserial's API. It is then also possible to use "socket://" type of URL's. Works on my elm327 over wifi and shouldn't break the current usage.