### PR TITLE
using async without a thread

### DIFF
--- a/obd/async.py
+++ b/obd/async.py
@@ -59,6 +59,30 @@ class Async(OBD):
         return self.__running
 
 
+    def main_loop(self):
+        """ Starts the async update loop without using thread """
+        if not self.is_connected():
+            logger.info("Async thread not started because no connection was made")
+            return
+
+        if len(self.__commands) == 0:
+            logger.info("Async thread not started because no commands were registered")
+            return
+
+        if self.__thread is None:
+            logger.info("Starting async thread")
+            self.__running = True
+            try:
+                self.__thread = Async.main_loop
+                self.run()
+            except Exception as e:
+                logger.info('Exception %s' % str(e))
+            if self.__thread is not None:
+                assert self.__thread == Async.main_loop
+                self.__running = False
+                self.__thread = None
+
+
     def start(self):
         """ Starts the async update loop """
         if not self.is_connected():


### PR DESCRIPTION
sometimes user needs to run async in his/her own thread instead to catch exceptions.

I added a main_loop() function so that I can control Async and get internal exceptions. In this way I can do something in case of hardware failure and I got disconnected.