### PR TITLE
Ignore non-decodeable data from the interface

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -463,7 +463,7 @@ class ELM327:
             buffer = buffer[:-1]
 
         # convert bytes into a standard string
-        string = buffer.decode()
+        string = buffer.decode("utf-8", "ignore")
 
         # splits into lines while removing empty lines and trailing spaces
         lines = [ s.strip() for s in re.split("[\r\n]", string) if bool(s) ]


### PR DESCRIPTION
This should fix #101 and close #103 by doing basically the same thing without all the IDE stuff.

I have tested this on my vehicle and it works.