### PR TITLE
Add support for ELM responding voltage with a 'V' to the obd.commands.ELM_VOLTAGE command

### DIFF
--- a/obd/decoders.py
+++ b/obd/decoders.py
@@ -234,6 +234,9 @@ def elm_voltage(messages):
     # doesn't register as a normal OBD response,
     # so access the raw frame data
     v = messages[0].frames[0].raw
+    # Some ELMs provide float V (for example messages[0].frames[0].raw => u'12.3V'
+    v = v.lower()
+    v = v.replace('v', '')
 
     try:
         return float(v) * Unit.volt

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -163,6 +163,7 @@ def test_elm_voltage():
     # these aren't parsed as standard hex messages, so manufacture our own
     assert d.elm_voltage([ Message([ Frame("12.875") ]) ]) == 12.875 * Unit.volt
     assert d.elm_voltage([ Message([ Frame("12") ]) ]) == 12 * Unit.volt
+    assert d.elm_voltage([ Message([ Frame(u'12.3V') ]) ]) == 12.3 * Unit.volt
     assert d.elm_voltage([ Message([ Frame("12ABCD") ]) ]) == None
 
 def test_status():


### PR DESCRIPTION
Added a cast to lower to also cover 'v'
Added a replace 'v' with empty string

========Console Proof of the problem=========
In [31]: c = obd.commands.ELM_VOLTAGE
In [32]: res = connection.query(c)
[obd.obd] Sending command: ATRV: Voltage detected by OBD-II adapter
[obd.elm327] write: 'ATRV\r\n'
[obd.elm327] read: b'12.3V\r\r>'
[obd.decoders] Failed to parse ELM voltage

In [34]: res.messages[0].frames[0].raw
Out[34]: u'12.3V'
