### PR TITLE
Fixed auto-baudrate for STN11xx

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -290,12 +290,14 @@ class ELM327:
             # so write a second one (again so that the lone CR doesn't repeat
             # the previous command)
             self.__port.write(b"\x7F\x7F\r\n")
+            self.__port.write(b"ATZ\r\n")
             self.__port.flush()
+            time.sleep(1)
             response = self.__port.read(1024)
             logger.debug("Response from baud %d: %s" % (baud, repr(response)))
 
             # watch for the prompt character
-            if response.endswith(b">"):
+            if response.endswith(self.ELM_PROMPT):
                 logger.debug("Choosing baud %d" % baud)
                 self.__port.timeout = timeout # reinstate our original timeout
                 return True


### PR DESCRIPTION
I have both the OBDLink SX and OBDLink MX which use the STN11xx chipset.  The auto-baudrate feature was not working for me until I made a few changes inside the ELM327.auto_baudrate() method.  This might help those with issue #58.  I've only been able to test with my SX and MX devices.  Please review and give me your thoughts.

Cheers,
Anthony