### PR TITLE
Fix command terminating characters to meet ELM327 and STN11XX specifications

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -289,7 +289,10 @@ class ELM327:
             # The first character might get eaten if the interface was busy,
             # so write a second one (again so that the lone CR doesn't repeat
             # the previous command)
-            self.__port.write(b"\x7F\x7F\r\n")
+
+            # All commands should be terminated with carriage return according 
+            # to ELM327 and STN11XX specifications
+            self.__port.write(b"\x7F\x7F\r")
             self.__port.flush()
             response = self.__port.read(1024)
             logger.debug("Response from baud %d: %s" % (baud, repr(response)))
@@ -415,7 +418,7 @@ class ELM327:
         """
 
         if self.__port:
-            cmd += b"\r\n" # terminate
+            cmd += b"\r" # terminate with carriage return in accordance with ELM327 and STN11XX specifications
             logger.debug("write: " + repr(cmd))
             self.__port.flushInput() # dump everything in the input buffer
             self.__port.write(cmd) # turn the string into bytes and write


### PR DESCRIPTION
According to both the ELM327 and STN11XX documentation, _we should be terminating our commands with carriage returns only_!

If we don't make this change, certain features of python-OBD will not work reliably due to inconsistent response behaviors from ELM327 and STN11XX chipsets when given improperly formatted commands.  For example, the auto baudrate feature does not always work, #58.  The cause of #58 for my STN-11XX chipset was due to the commands being terminated with **\r\n** instead of **\r**, the latter being in line with ELM327 and STN11XX specifications.  Prior to this change, my chipset responded inconsistently even when given the exact same command more than once.  After changing to carriage return only, the auto baudrate feature worked as expected and the chip responded in a consistent manner with the same response each and every time respective to its command.

**Just to be clear, I'm talking about commands only.** Responses are a bit different and can be **\r** or **\r\n** depending on (AT L1 or AT L0 commands) settings which are also listed within the documentation.

**Here's the documentation that I found for the STN chip and ELM chip.**

http://www.kds-online.com/Downloads/OBD/OBDLink_STN11xx-ds.pdf
https://www.elmelectronics.com/wp-content/uploads/2016/07/ELM327DS.pdf

**STN11XX Documentation**
"All commands must terminate with a carriage return (0x0D)" (Page 6 of 20)

"By default, responses from the STN11XX are terminated with a carriage return (0x0D). ATL1 command can be used to have the STN11XX append line feeds (0x0A) to the carriage returns." (Page 6 of 20)

**ELM327 Documentation**
"Whether it is an ‘AT’ type internal command or a hex string for the OBD bus, all messages to the ELM327 must be terminated with a carriage return character (hex ‘0D’) before it will be acted upon." (Page 8 of 94)

"All of the responses from the ELM327 are terminated with a single carriage return character and, optionally, a linefeed character (depending on your settings)." (Page 8 of 94)

**Conclusion**
We should change the command terminating characters from **\r\n** to **\r** to meet ELM327 and STN11XX specifications and help mitigate or get rid of some of the other existing bugs such as #58 and perhaps even more for which I am currently unaware.

Obviously, we'll need to do lots testing since this change could have a pretty big impact.

Cheers,
Anthony