### PR TITLE
Catch 'UNABLE TO CONNECT' when first querying protocol 0100

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -220,6 +220,9 @@ class ELM327:
 
         # -------------- 0100 (first command, SEARCH protocols) --------------
         r0100 = self.__send(b"0100")
+        if self.__has_message(r0100, "UNABLE TO CONNECT"):
+            logger.error("Failed to query protocol 0100: unable to connect")
+            return False
 
         # ------------------- ATDPN (list protocol number) -------------------
         r = self.__send(b"ATDPN")


### PR DESCRIPTION
**Catch 'UNABLE TO CONNECT' when first querying protocol 0100**

Catch ELM327 response '*UNABLE TO CONNECT*' when first querying protocol 0100 so that the CAR_CONNECTED status is returned when the adapter is connected and the ignition is on (`status() == 'Car Connected'`), while `status()` returns 'ELM Connected' if the adapter is not connected or if the adapter is connected and the ignition is off.

Fixes https://github.com/brendan-w/python-OBD/issues/124

Test program:
```
import obd
import sys
obd.logger.setLevel(obd.logging.DEBUG)
connection = obd.OBD(sys.argv[1])
print(connection.status())
print(connection.query(obd.commands.RPM))
```

Output when the adapter is connected and when the ignition is on:
```
[obd.obd] ======================= python-OBD (v0.7.0) =======================
[obd.obd] Explicit port defined
[obd.elm327] Initializing ELM327: PORT=/dev/pts/1 BAUD=auto PROTOCOL=auto
[obd.elm327] Detected pseudo terminal, skipping baudrate setup
[obd.elm327] write: b'ATZ\r'
[obd.elm327] wait: 1 seconds
[obd.elm327] read: b'\r\rELM327 v1.5\r\r>'
[obd.elm327] write: b'ATE0\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'ATH1\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'ATL0\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'ATSP0\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'0100\r'
[obd.elm327] read: b'SEARCHING...\r7EA 06 41 00 98 3A 80 13 \r7E8 06 41 00 BE 3F A8 13 \r\r>'
[obd.elm327] write: b'ATDPN\r'
[obd.elm327] read: b'A6\r\r>'
[obd.protocols.protocol] map ECU 0 --> ENGINE
[obd.protocols.protocol] map ECU 2 --> UNKNOWN
[obd.elm327] Connected Successfully: PORT=/dev/pts/1 BAUD=9600 PROTOCOL=6
[obd.obd] querying for supported commands
[obd.obd] Sending command: b'0100': Supported PIDs [01-20]
[obd.elm327] write: b'0100\r'
[obd.elm327] read: b'7EA 06 41 00 98 3A 80 13 \r7E8 06 41 00 BE 3F A8 13 \r\r>'
[obd.obd] Sending command: b'0120': Supported PIDs [21-40]
[obd.elm327] write: b'0120\r'
[obd.elm327] read: b'7EA 06 41 20 80 01 A0 01 \r7E8 06 41 20 90 15 B0 15 \r\r>'
[obd.obd] Sending command: b'0140': Supported PIDs [41-60]
[obd.elm327] write: b'0140\r'
[obd.elm327] read: b'7EA 06 41 40 44 CC 00 21 \r7E8 06 41 40 7A 1C 80 00 \r\r>'
[obd.obd] Sending command: b'0600': Supported MIDs [01-20]
[obd.elm327] write: b'0600\r'
[obd.elm327] read: b'7E8 06 46 00 C0 00 00 01 \r\r>'
[obd.obd] Sending command: b'0620': Supported MIDs [21-40]
[obd.elm327] write: b'0620\r'
[obd.elm327] read: b'7E8 06 46 20 80 00 80 01 \r\r>'
[obd.obd] Sending command: b'0640': Supported MIDs [41-60]
[obd.elm327] write: b'0640\r'
[obd.elm327] read: b'7E8 06 46 40 00 00 00 01 \r\r>'
[obd.obd] Sending command: b'0660': Supported MIDs [61-80]
[obd.elm327] write: b'0660\r'
[obd.elm327] read: b'7E8 06 46 60 00 00 00 01 \r\r>'
[obd.obd] Sending command: b'0680': Supported MIDs [81-A0]
[obd.elm327] write: b'0680\r'
[obd.elm327] read: b'7E8 06 46 80 00 00 00 01 \r\r>'
[obd.obd] Sending command: b'06A0': Supported MIDs [A1-C0]
[obd.elm327] write: b'06A0\r'
[obd.elm327] read: b'7E8 06 46 A0 F8 00 00 00 \r\r>'
[obd.obd] finished querying with 97 commands supported
[obd.obd] ===================================================================
Car Connected
[obd.obd] Sending command: b'010C': Engine RPM
[obd.elm327] write: b'010C\r'
[obd.elm327] read: b'7E8 04 41 0C 17 20 \r7EA 04 41 0C 17 20 \r\r>'
1480.0 revolutions_per_minute
```

Output when the adapter is not connected or when the ignition is off:
```
[obd.obd] ======================= python-OBD (v0.7.0) =======================
[obd.obd] Explicit port defined
[obd.elm327] Initializing ELM327: PORT=/dev/ttyUSB0 BAUD=auto PROTOCOL=auto
[obd.elm327] Response from baud 38400: b'?\r\r>'
[obd.elm327] Choosing baud 38400
[obd.elm327] write: b'ATZ\r'
[obd.elm327] wait: 1 seconds
[obd.elm327] read: b'\xfc\r\rELM327 v1.5\r\r>'
[obd.elm327] write: b'ATE0\r'
[obd.elm327] read: b'ATE0\rOK\r\r>'
[obd.elm327] write: b'ATH1\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'ATL0\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'ATSP0\r'
[obd.elm327] read: b'OK\r\r>'
[obd.elm327] write: b'0100\r'
[obd.elm327] read: b'SEARCHING...\rUNABLE TO CONNECT\r\r>'
[obd.elm327] Failed to query protocol 0100: unable to connect
[obd.elm327] Connected to the adapter, but failed to connect to the vehicle
[obd.obd] Cannot load commands: No connection to car
[obd.obd] ===================================================================
ELM Connected
[obd.obd] 'b'010C': Engine RPM' is not supported
None
```

Before this fix, "Car Connected" was always returned with ELM327 v1.5 processor.