### PR TITLE
Add support for the ELM327 Low Power mode

### DIFF
--- a/docs/Connections.md
+++ b/docs/Connections.md
@@ -20,7 +20,7 @@ connection = obd.OBD(ports[0]) # connect to the first port in the list
 
 <br>
 
-### OBD(portstr=None, baudrate=None, protocol=None, fast=True, timeout=0.1, check_voltage=True):
+### OBD(portstr=None, baudrate=None, protocol=None, fast=True, timeout=0.1, check_voltage=True, start_low_power=False):
 
 `portstr`: The UNIX device file or Windows COM Port for your adapter. The default value (`None`) will auto select a port.
 
@@ -38,6 +38,8 @@ Disabling fast mode will guarantee that python-OBD outputs the unaltered command
 `timeout`: Specifies the connection timeout in seconds.
 
 `check_voltage`: Optional argument that is `True` by default and when set to `False` disables the detection of the car supply voltage on OBDII port (which should be about 12V). This control assumes that, if the voltage is lower than 6V, the OBDII port is disconnected from the car. If the option is enabled, it adds the `OBDStatus.OBD_CONNECTED` status, which is set when enough voltage is returned (socket connected to the car) but the ignition is off (no communication with the vehicle). Setting the option to `False` should be needed when the adapter does not support the voltage pin or more generally when the hardware provides unreliable results, or if the pin reads the switched ignition voltage rather than the battery positive (this depends on the car).
+
+`start_low_power`: Optional argument that defaults to `False`. If set to `True` the initial connection will take longer (roughly 1 more second) but will support waking the ELM327 from low power mode before starting the connection. It does this by sending a space to the chip to trigger a charecter being received on the RS232 input line. This is sent before the baud rate is setup, to ensure the device is awake to detect the baud rate.
 
 <br>
 

--- a/obd/asynchronous.py
+++ b/obd/asynchronous.py
@@ -46,9 +46,10 @@ class Async(OBD):
     """
 
     def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
-                 timeout=0.1, check_voltage=True, delay_cmds=0.25):
+                 timeout=0.1, check_voltage=True, start_low_power=False,
+                 delay_cmds=0.25):
         super(Async, self).__init__(portstr, baudrate, protocol, fast,
-                                    timeout, check_voltage)
+                                    timeout, check_voltage, start_low_power)
         self.__commands = {}   # key = OBDCommand, value = Response
         self.__callbacks = {}  # key = OBDCommand, value = list of Functions
         self.__thread = None

--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -104,7 +104,7 @@ class ELM327:
     _TRY_BAUDS = [38400, 9600, 230400, 115200, 57600, 19200]
 
     def __init__(self, portname, baudrate, protocol, timeout,
-                 check_voltage=True):
+                 check_voltage=True, start_low_power=False):
         """Initializes port by resetting device and gettings supported PIDs. """
 
         logger.info("Initializing ELM327: PORT=%s BAUD=%s PROTOCOL=%s" %
@@ -133,6 +133,11 @@ class ELM327:
         except OSError as e:
             self.__error(e)
             return
+
+        # If we start with the IC in the low power state we need to wake it up
+        if start_low_power:
+            self.__write(b" ")
+            time.sleep(1)
 
         # ------------------------ find the ELM's baud ------------------------
 

--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -56,6 +56,7 @@ class ELM327:
     """
 
     ELM_PROMPT = b'>'
+    ELM_LP_ACTIVE = b'OK'
 
     _SUPPORTED_PROTOCOLS = {
         # "0" : None,
@@ -116,6 +117,7 @@ class ELM327:
         self.__status = OBDStatus.NOT_CONNECTED
         self.__port = None
         self.__protocol = UnknownProtocol([])
+        self.__low_power = False
         self.timeout = timeout
 
         # ------------- open port -------------
@@ -362,6 +364,62 @@ class ELM327:
     def protocol_id(self):
         return self.__protocol.ELM_ID
 
+    def low_power(self):
+        """
+            Enter Low Power mode
+
+            This command causes the ELM327 to shut off all but essential
+            services.
+
+            The ELM327 can be woken up by a message to the RS232 bus as
+            well as a few other ways. See the Power Control section in
+            the ELM327 datasheet for details on other ways to wake up
+            the chip.
+
+            Returns the status from the ELM327, 'OK' means low power mode
+            is going to become active.
+        """
+
+        if self.__status == OBDStatus.NOT_CONNECTED:
+            logger.info("cannot enter low power when unconnected")
+            return None
+
+        lines = self.__send(b"ATLP", delay=1)
+
+        if 'OK' in lines:
+            logger.debug("Successfully entered low power mode")
+            self.__low_power = True
+        else:
+            logger.debug("Failed to enter low power mode")
+
+        return lines
+
+    def normal_power(self):
+        """
+            Exit Low Power mode
+
+            Send a space to trigger the RS232 to wakeup.
+
+            This will send a space even if we aren't in low power mode as
+            we want to ensure that we will be able to leave low power mode.
+
+            See the Power Control section in the ELM327 datasheet for details
+            on other ways to wake up the chip.
+
+            Returns the status from the ELM327.
+        """
+        if self.__status == OBDStatus.NOT_CONNECTED:
+            logger.info("cannot exit low power when unconnected")
+            return None
+
+        lines = self.__send(b" ")
+
+        # Assume we woke up
+        logger.debug("Successfully exited low power mode")
+        self.__low_power = False
+
+        return lines
+
     def close(self):
         """
             Resets the device, and sets all
@@ -392,6 +450,10 @@ class ELM327:
         if self.__status == OBDStatus.NOT_CONNECTED:
             logger.info("cannot send_and_parse() when unconnected")
             return None
+
+        # Check if we are in low power
+        if self.__low_power == True:
+            self.normal_power()
 
         lines = self.__send(cmd)
         messages = self.__protocol(lines)
@@ -466,8 +528,9 @@ class ELM327:
 
             buffer.extend(data)
 
-            # end on chevron (ELM prompt character)
-            if self.ELM_PROMPT in buffer:
+            # end on chevron (ELM prompt character) or an 'OK' which
+            # indicates we are entering low power state
+            if self.ELM_PROMPT in buffer or self.ELM_LP_ACTIVE in buffer:
                 break
 
         # log, and remove the "bytearray(   ...   )" part

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -50,7 +50,7 @@ class OBD(object):
     """
 
     def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
-                 timeout=0.1, check_voltage=True):
+                 timeout=0.1, check_voltage=True, start_low_power=False):
         self.interface = None
         self.supported_commands = set(commands.base_commands())
         self.fast = fast  # global switch for disabling optimizations
@@ -61,11 +61,12 @@ class OBD(object):
 
         logger.info("======================= python-OBD (v%s) =======================" % __version__)
         self.__connect(portstr, baudrate, protocol,
-                       check_voltage)  # initialize by connecting and loading sensors
+                       check_voltage, start_low_power)  # initialize by connecting and loading sensors
         self.__load_commands()  # try to load the car's supported commands
         logger.info("===================================================================")
 
-    def __connect(self, portstr, baudrate, protocol, check_voltage):
+    def __connect(self, portstr, baudrate, protocol, check_voltage,
+                  start_low_power):
         """
             Attempts to instantiate an ELM327 connection object.
         """
@@ -82,14 +83,16 @@ class OBD(object):
             for port in port_names:
                 logger.info("Attempting to use port: " + str(port))
                 self.interface = ELM327(port, baudrate, protocol,
-                                        self.timeout, check_voltage)
+                                        self.timeout, check_voltage,
+                                        start_low_power)
 
                 if self.interface.status() >= OBDStatus.ELM_CONNECTED:
                     break  # success! stop searching for serial
         else:
             logger.info("Explicit port defined")
             self.interface = ELM327(portstr, baudrate, protocol,
-                                    self.timeout, check_voltage)
+                                    self.timeout, check_voltage,
+                                    start_low_power)
 
         # if the connection failed, close it
         if self.interface.status() == OBDStatus.NOT_CONNECTED:

--- a/obd/obd.py
+++ b/obd/obd.py
@@ -170,6 +170,20 @@ class OBD(object):
         else:
             return self.interface.status()
 
+    def low_power(self):
+        """ Enter low power mode """
+        if self.interface is None:
+            return OBDStatus.NOT_CONNECTED
+        else:
+            return self.interface.low_power()
+
+    def normal_power(self):
+        """ Exit low power mode """
+        if self.interface is None:
+            return OBDStatus.NOT_CONNECTED
+        else:
+            return self.interface.normal_power()
+
     # not sure how useful this would be
 
     # def ecus(self):


### PR DESCRIPTION
Add support for entering low power mode. By sending a ATLP command we can tell the ELM327 to enter low power mode. We also add support for leaving low power mode by sending a space.