### PR TITLE
Avoiding Async exception on serial port failure

### DIFF
--- a/obd/asynchronous.py
+++ b/obd/asynchronous.py
@@ -48,11 +48,11 @@ class Async(OBD):
     def __init__(self, portstr=None, baudrate=None, protocol=None, fast=True,
                  timeout=0.1, check_voltage=True, start_low_power=False,
                  delay_cmds=0.25):
+        self.__thread = None
         super(Async, self).__init__(portstr, baudrate, protocol, fast,
                                     timeout, check_voltage, start_low_power)
         self.__commands = {}   # key = OBDCommand, value = Response
         self.__callbacks = {}  # key = OBDCommand, value = list of Functions
-        self.__thread = None
         self.__running = False
         self.__was_running = False  # used with __enter__() and __exit__()
         self.__delay_cmds = delay_cmds


### PR DESCRIPTION
**Fix obd.Async() exception when failing to open the serial device.**

Fixed exception:
*AttributeError: 'Async' object has no attribute '_Async__thread'*

Fixes https://github.com/brendan-w/python-OBD/issues/67

Testing program:

```
import obd
import sys
connection = obd.Async(sys.argv[1])
```

**Before the patch:**

- No exception:
  `python3 test-async.py /dev/existing-device`

- Exception:
  `python3 test-async.py /dev/unexisting-device`
  AttributeError: 'Async' object has no attribute '_Async__thread'

**After the patch:**

- `python3 test-async.py /dev/existing-device`
  no exception

- `python3 test-async.py /dev/unexisting-device`
  [obd.elm327] [Errno 2] could not open port /dev/unexisting-device:
[Errno 2] No such file or directory: '/dev/unexisting-device'
  [obd.obd] Cannot load commands: No connection to car