### PR TITLE
Add __repr__ to OBDCommand

### DIFF
--- a/obd/OBDCommand.py
+++ b/obd/OBDCommand.py
@@ -114,6 +114,9 @@ class OBDCommand:
 
     def __str__(self):
         return "%s: %s" % (self.command, self.desc)
+    
+    def __repr(self):
+        return "OBDCommand(%s, %s)" % (self.name, self.command)
 
     def __hash__(self):
         # needed for using commands as keys in a dict (see async.py)


### PR DESCRIPTION
Better representation of a container of `OBDCommand`s.

### Before
```python
>>> obd.commands.base_commands()
[<obd.OBDCommand.OBDCommand object at 0x7f3945cb7160>, <obd.OBDCommand.OBDCommand object at 0x7f393835f3c8>, <obd.OBDCommand.OBDCommand object at 0x7f3938361d68>, <obd.OBDCommand.OBDCommand object at 0x7f393835f390>, <obd.OBDCommand.OBDCommand object at 0x7f3938349748>, <obd.OBDCommand.OBDCommand object at 0x7f3938349780>, <obd.OBDCommand.OBDCommand object at 0x7f39383497b8>]
```

### After
```python
>>> obd.commands.base_commands()
[OBDCommand(PIDS_A, b'0100'), OBDCommand(MIDS_A, b'0600'), OBDCommand(GET_DTC, b'03'), OBDCommand(CLEAR_DTC, b'04'), OBDCommand(GET_CURRENT_DTC, b'07'), OBDCommand(ELM_VERSION, b'ATI'), OBDCommand(ELM_VOLTAGE, b'ATRV')]

>>> print("\n".join(map(repr, obd.commands.base_commands())))
OBDCommand(PIDS_A, b'0100')
OBDCommand(MIDS_A, b'0600')
OBDCommand(GET_DTC, b'03')
OBDCommand(CLEAR_DTC, b'04')
OBDCommand(GET_CURRENT_DTC, b'07')
OBDCommand(ELM_VERSION, b'ATI')
OBDCommand(ELM_VOLTAGE, b'ATRV')
```
