### PR TITLE
Fix 'toy command' class type used for testing

### DIFF
--- a/tests/test_OBD.py
+++ b/tests/test_OBD.py
@@ -61,7 +61,7 @@ class FakeELM:
 # a toy command to test with
 command = OBDCommand("Test_Command",
                      "A test command",
-                     "0123456789ABCDEF",
+                     b"0123456789ABCDEF",
                      0,
                      noop,
                      ECU.ALL,


### PR DESCRIPTION
It should be 'bytes' type and not string.