### PR TITLE
Better message size error

### DIFF
--- a/obd/OBDCommand.py
+++ b/obd/OBDCommand.py
@@ -103,18 +103,21 @@ class OBDCommand:
 
     def __constrain_message_data(self, message):
         """ pads or chops the data field to the size specified by this command """
+        len_msg_data = len(message.data)
         if self.bytes > 0:
-            if len(message.data) > self.bytes:
+            if len_msg_data > self.bytes:
                 # chop off the right side
                 message.data = message.data[:self.bytes]
                 logger.debug(
-                    "Message was longer than expected. Trimmed message: " +
+                    "Message was longer than expected (%s>%s). " +
+                    "Trimmed message: %s", len_msg_data, self.bytes,
                     repr(message.data))
-            elif len(message.data) < self.bytes:
+            elif len_msg_data < self.bytes:
                 # pad the right with zeros
-                message.data += (b'\x00' * (self.bytes - len(message.data)))
+                message.data += (b'\x00' * (self.bytes - len_msg_data))
                 logger.debug(
-                    "Message was shorter than expected. Padded message: " +
+                    "Message was shorter than expected (%s<%s). " +
+                    "Padded message: %s", len_msg_data, self.bytes,
                     repr(message.data))
 
     def __str__(self):


### PR DESCRIPTION
Adding actual size and expected size of response error messages in case of wrong size.

This helps checking the size of custom PIDs (e.g., 4th parameter of `OBDCommand`).

**Example 1**

In the following custom command, the right size should be 8.

```
shift_l = OBDCommand(
        "Shift_J",
        "Shift Joystick",
        b"2141",
        7, # instead of 8
        Shift_J,
        ECU.ALL,
        True,
        header=b'7E2'
        )
```

Before:
[obd.OBDCommand] Message was longer than expected. Trimmed message: bytearray(b'aA\xc5\xc6\xb5\xb28')

After:
[obd.OBDCommand] Message was longer than expected **(8>7)**. Trimmed message: bytearray(b'aA\xc5\xc6\xb5\xb28')

**Example 2**

```
shift_l = OBDCommand(
        "Shift_J",
        "Shift Joystick",
        b"2141",
        9, # instead of 8
        Shift_J,
        ECU.ALL,
        True,
        header=b'7E2'
        )
```

Before:
[obd.OBDCommand] Message was shorter than expected. Padded message: bytearray(b'aA\xc4\xc4\xb5\xb28\x89\x00')

After:
[obd.OBDCommand] Message was shorter than expected **(8<9)**. Padded message: bytearray(b'aA\xc4\xc4\xb5\xb28\x89\x00')
