### PR TITLE
Minor change to the protocol values

### DIFF
--- a/docs/Connections.md
+++ b/docs/Connections.md
@@ -120,16 +120,18 @@ Both functions return string names for the protocol currently being used by the 
 
 |ID | Name                     |
 |---|--------------------------|
-| 1 | SAE J1850 PWM            |
-| 2 | SAE J1850 VPW            |
-| 3 | AUTO, ISO 9141-2         |
-| 4 | ISO 14230-4 (KWP 5BAUD)  |
-| 5 | ISO 14230-4 (KWP FAST)   |
-| 6 | ISO 15765-4 (CAN 11/500) |
-| 7 | ISO 15765-4 (CAN 29/500) |
-| 8 | ISO 15765-4 (CAN 11/250) |
-| 9 | ISO 15765-4 (CAN 29/250) |
-| A | SAE J1939 (CAN 29/250)   |
+| "1" | SAE J1850 PWM            |
+| "2" | SAE J1850 VPW            |
+| "3" | AUTO, ISO 9141-2         |
+| "4" | ISO 14230-4 (KWP 5BAUD)  |
+| "5" | ISO 14230-4 (KWP FAST)   |
+| "6" | ISO 15765-4 (CAN 11/500) |
+| "7" | ISO 15765-4 (CAN 29/500) |
+| "8" | ISO 15765-4 (CAN 11/250) |
+| "9" | ISO 15765-4 (CAN 29/250) |
+| "A" | SAE J1939 (CAN 29/250)   |
+
+*Note the quotations around the possible IDs*
 
 ---
 


### PR DESCRIPTION
While the documentation had no quotes, the code needed the quotes. Passing obd.Async(port, protocol="3") is the correct way not obd.Async(port, protocol=3). While this is evident from reading the code, this change makes is more evident.