### PR TITLE
Fix send delay for bluetooth/Raspberry Pi

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -472,14 +472,22 @@ class ELM327:
             returns result of __read() (a list of line strings)
             after an optional delay.
         """
-
         self.__write(cmd)
 
+        delayed = 0.0
         if delay is not None:
             logger.debug("wait: %d seconds" % delay)
             time.sleep(delay)
+            delayed += delay
 
-        return self.__read()
+        r = self.__read()
+        while delayed < 1.0 and len(r) <= 0:
+            d = 0.1
+            logger.debug("no response; wait: %f seconds" % d)
+            time.sleep(d)
+            delayed += d
+            r = self.__read()
+        return r
 
     def __write(self, cmd):
         """


### PR DESCRIPTION
This corrects the following issue, detected on a Raspberry Pi connecting via Bluetooth (though it may not be exclusive to this case): https://github.com/brendan-w/python-OBD/issues/160

The root cause was that the `send` command was attempting to retrieve responses from the OBD adapter before they were available for the startup commands (likely due to latency over Bluetooth or some slowness with the dongle itself). I verified that each of `ATH1`, `ATL0`, and `AT RV` would not work on my Raspberry Pi 4 with bluetooth without using at least a 0.1 second delay. 

My first thought was to use the `fast=False` configuration value to add a delay to `__send()`, but on experimentation I discovered that this created an artificial delay which was unnecessary for retrieving values later (such as `SPEED`). Instead, I modified the `__send()` function to retry the `read()` if the response was empty for up to one second. AFAIK, this should not be problematic in that a response is always expected by any monitoring commands sent to the OBDII adapter.

... but I defer to the maintainers, as I only just started reading about the OBDII/ELM327 protocol specifics today.

// fyi @alistair23 @ajalberd 