### PR TITLE
Add support for Mode 9 PIDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Here are a handful of the supported commands (sensors). For a full list, see [th
 -   Time since trouble codes cleared
 -   Hybrid battery pack remaining life
 -   Engine fuel rate
+-   Vehicle Identification Number (VIN)
 
 Common Issues
 -------------

--- a/docs/Command Tables.md
+++ b/docs/Command Tables.md
@@ -261,3 +261,25 @@ The return value will be encoded in the same structure as the Mode 03 `GET_DTC` 
 | N/A | GET_CURRENT_DTC | Get DTCs from the current/last driving cycle | [special](Responses.md#diagnostic-trouble-codes-dtcs) |
 
 <br>
+
+# Mode 09
+
+<span style="color:red">*WARNING: mode 09 is experimental. While it has been tested on a hardware simulator, only a subset of the supported
+commands have (00-06) been tested. Any debug output for this mode, especially for the untested PIDs, would be greatly appreciated.*</span>
+
+|PID | Name                         | Description                                        | Response Value        |
+|----|------------------------------|----------------------------------------------------|-----------------------|
+| 00 | PIDS_9A                      | Supported PIDs [01-20]                             | BitArray              |
+| 01 | VIN_MESSAGE_COUNT            | VIN Message Count                                  | Unit.count            |
+| 02 | VIN                          | Vehicle Identification Number                      | string                |
+| 03 | CALIBRATION_ID_MESSAGE_COUNT | Calibration ID message count for PID 04            | Unit.count            |
+| 04 | CALIBRATION_ID               | Calibration ID                                     | string                |
+| 05 | CVN_MESSAGE_COUNT            | CVN Message Count for PID 06                       | Unit.count            |
+| 06 | CVN                          | Calibration Verification Numbers                   | hex string            |
+| 07 | PERF_TRACKING_MESSAGE_COUNT  | Performance tracking message count                 | TODO                  |
+| 08 | PERF_TRACKING_SPARK          | In-use performance tracking (spark ignition)       | TODO                  |
+| 09 | ECU_NAME_MESSAGE_COUNT       | ECU Name Message Count for PID 0A                  | TODO                  |
+| 0a | ECU_NAME                     | ECU Name                                           | TODO                  |
+| 0b | PERF_TRACKING_COMPRESSION    | In-use performance tracking (compression ignition) | TODO                  |
+
+<br>

--- a/obd/commands.py
+++ b/obd/commands.py
@@ -279,6 +279,27 @@ __mode7__ = [
     OBDCommand("GET_CURRENT_DTC", "Get DTCs from the current/last driving cycle", b"07", 0, dtc, ECU.ALL, False),
 ]
 
+
+__mode9__ = [
+    #                      name                             description                            cmd     bytes       decoder       ECU        fast
+    OBDCommand("PIDS_9A"                    , "Supported PIDs [01-20]"                            , b"0900",  7, pid,                ECU.ALL,     True),
+    OBDCommand("VIN_MESSAGE_COUNT"          , "VIN Message Count"                                 , b"0901",  3, count,              ECU.ENGINE,  True),
+    OBDCommand("VIN"                        , "Vehicle Identification Number"                     , b"0902", 22, encoded_string(17), ECU.ENGINE,  True),
+    OBDCommand("CALIBRATION_ID_MESSAGE_COUNT","Calibration ID message count for PID 04"           , b"0903",  3, count,              ECU.ALL,     True),
+    OBDCommand("CALIBRATION_ID"             , "Calibration ID"                                    , b"0904", 18, encoded_string(16), ECU.ALL,     True),
+    OBDCommand("CVN_MESSAGE_COUNT"          , "CVN Message Count for PID 06"                      , b"0905",  3, count,              ECU.ALL,     True),
+    OBDCommand("CVN"                        , "Calibration Verification Numbers"                  , b"0906", 10, cvn,                ECU.ALL,     True),
+
+#
+# NOTE: The following are untested
+#
+#    OBDCommand("PERF_TRACKING_MESSAGE_COUNT", "Performance tracking message count"                , b"0907",  3, count,              ECU.ALL,     True),
+#    OBDCommand("PERF_TRACKING_SPARK"        , "In-use performance tracking (spark ignition)"      , b"0908",  4, raw_string,         ECU.ALL,     True),
+#    OBDCommand("ECU_NAME_MESSAGE_COUNT"     , "ECU Name Message Count for PID 0A"                 , b"0909",  3, count,              ECU.ALL,     True),
+#    OBDCommand("ECU_NAME"                   , "ECU Name"                                          , b"090a", 20, raw_string,         ECU.ALL,     True),
+#    OBDCommand("PERF_TRACKING_COMPRESSION"  , "In-use performance tracking (compression ignition)", b"090b",  4, raw_string,         ECU.ALL,     True),
+]
+
 __misc__ = [
     OBDCommand("ELM_VERSION", "ELM327 version string", b"ATI", 0, raw_string, ECU.UNKNOWN, False),
     OBDCommand("ELM_VOLTAGE", "Voltage detected by OBD-II adapter", b"ATRV", 0, elm_voltage, ECU.UNKNOWN, False),
@@ -303,6 +324,7 @@ class Commands():
             __mode6__,
             __mode7__,
             [],
+            __mode9__,
         ]
 
         # allow commands to be accessed by name
@@ -350,6 +372,7 @@ class Commands():
         """
         return [
             self.PIDS_A,
+            self.PIDS_9A,
             self.MIDS_A,
             self.GET_DTC,
             self.CLEAR_DTC,

--- a/obd/decoders.py
+++ b/obd/decoders.py
@@ -94,6 +94,10 @@ General sensor decoders
 Return pint Quantities
 """
 
+def count(messages):
+    d = messages[0].data[2:]
+    v = bytes_to_int(d)
+    return v * Unit.count
 
 # 0 to 100 %
 def percent(messages):
@@ -484,3 +488,28 @@ def monitor(messages):
             mon.add_test(test)
 
     return mon
+
+
+def encoded_string(length):
+    """ Extract an encoded string from multi-part messages """
+    return functools.partial(decode_encoded_string, length=length)
+
+
+def decode_encoded_string(messages, length):
+    d = messages[0].data[2:]
+
+    if len(d) < length:
+        logger.debug("Invalid string {}. Discarding...", d)
+        return None
+
+    # Encoded strings come in bundles of messages with leading null values to
+    # pad out the string to the next full message size. We strip off the
+    # leading null characters here and return the resulting string.
+    return d.strip().strip(b'\x00' b'\x01' b'\x02' b'\\x00' b'\\x01' b'\\x02')
+
+
+def cvn(messages):
+    d = decode_encoded_string(messages, 4)
+    if d is None:
+        return None
+    return bytes_to_hex(d)

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -295,6 +295,14 @@ def test_dtc():
         ("B0003", ""),
     ]
 
+def test_vin_message_count():
+    assert d.count(m("0901")) == 0
+
+def test_vin():
+    assert d.encoded_string(17)(m("0201575030" + "5A5A5A39395A54" + "53333932313234")) == bytearray(b'WP0ZZZ99ZTS392124')
+
+def test_cvn():
+     assert d.cvn(m("6021791bc8216e0b")) == '791bc8216e'
 
 def test_monitor():
     # single test -----------------------------------------


### PR DESCRIPTION
This is baed on the original work by Paul Mundt
(https://github.com/brendan-w/python-OBD/pull/151).

This patch includes adding a simple git test case.

This will finally fix: https://github.com/brendan-w/python-OBD/issues/42

Signed-off-by: Alistair Francis <alistair@alistair23.me>