### PR TITLE
Patch invalid protocol error message.

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -210,7 +210,9 @@ class ELM327:
         if protocol_ is not None:
             # an explicit protocol was specified
             if protocol_ not in self._SUPPORTED_PROTOCOLS:
-                logger.error("%s is not a valid protocol. Please use \"1\" through \"A\"")
+                logger.error(
+                    "{:} is not a valid protocol. ".format(protocol_) +
+                    "Please use \"1\" through \"A\"")
                 return False
             return self.manual_protocol(protocol_)
         else:


### PR DESCRIPTION
This is just a quick fix to the error message logged when an invalid ELM327 proto is requested. Tested in py27.