### PR TITLE
travis: Update the Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 sudo: false
 
-
 install:
   - pip install tox
 
@@ -10,6 +9,8 @@ matrix:
   include:
     - python: '3.6'
       env: TOXENV=check36
+    - python: '3.8'
+      env: TOXENV=check38
     - python: '3.4'
       env: TOXENV=py34
     - python: '3.5'
@@ -18,6 +19,8 @@ matrix:
       env: TOXENV=py36
     - python: '3.7'
       env: TOXENV=py37
+    - python: '3.8'
+      env: TOXENV=py38
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ install:
 
 matrix:
   include:
-    - python: '2.7'
-      env: TOXENV=check27
     - python: '3.6'
       env: TOXENV=check36
-    - python: '2.7'
-      env: TOXENV=py27
     - python: '3.4'
       env: TOXENV=py34
     - python: '3.5'

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-    check{27,36},
-    py{27,py,34,35,36,37},
+    check{36},
+    py{34,35,36,37},
     coverage
-
 
 [testenv]
 usedevelop = true
@@ -19,22 +18,9 @@ commands =
     rm -vf {toxinidir}/.coverage_{envname}
     pytest --cov-report= --cov=obd {posargs}
 
-[testenv:check27]
-basepython = python2.7
-skipsdist = true
-deps =
-    check-manifest==0.37
-    flake8==3.7.7
-commands =
-    flake8 {envsitepackagesdir}/obd
-    python setup.py check --strict --metadata
-
-
 [testenv:check36]
 basepython = python3.6
 skipsdist = true
-deps = {[testenv:check27]deps}
-commands = {[testenv:check27]commands}
 
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    check{36},
-    py{34,35,36,37},
+    check{36,38},
+    py{34,35,36,37,38},
     coverage
 
 [testenv]


### PR DESCRIPTION
Drop testing for Python2 as it's unsupported. Let's also add tests for Python 3.8.