### PR TITLE
Fix ECU ID for legacy protocol

### DIFF
--- a/obd/protocols/protocol.py
+++ b/obd/protocols/protocol.py
@@ -146,6 +146,12 @@ class Protocol(object):
         # for example: self.TX_ID_ENGINE : ECU.ENGINE
         self.ecu_map = {}
 
+        if (self.TX_ID_ENGINE is not None):
+            self.ecu_map[self.TX_ID_ENGINE] = ECU.ENGINE
+
+        if (self.TX_ID_TRANSMISSION is not None):
+            self.ecu_map[self.TX_ID_TRANSMISSION] = ECU.TRANSMISSION
+
         # parse the 0100 data into messages
         # NOTE: at this point, their "ecu" property will be UNKNOWN
         messages = self(lines_0100)


### PR DESCRIPTION
 #### Issues Addressed
 When using OBD over legacy protocols like K-line the
 message is rejected because the ecu id is undefined
 even if the data is retrieved correctly.

 #### Summary of changes
 Add the ENGINE ID and TRANSMISSION ID to the list of ecu
 map at object creation time to have it available when
 receiving the message.

 #### Summary of testing
 Data is retrieved correctly on K-Line. Car used VW Lupo GTI
 Data is retrieved correctly on CAN cars. Car used Ford Focus.

Signed-off-by: Catalin Ghenea <catalin.ghenea@gmail.com>