### PR TITLE
Support slow OBD adapters

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -244,7 +244,7 @@ class ELM327:
         r = self.__send(b"ATSP0")
 
         # -------------- 0100 (first command, SEARCH protocols) --------------
-        r0100 = self.__send(b"0100")
+        r0100 = self.__send(b"0100", delay=1)
         if self.__has_message(r0100, "UNABLE TO CONNECT"):
             logger.error("Failed to query protocol 0100: unable to connect")
             return False


### PR DESCRIPTION
Increase "0100" query (PIDS_A) timeout to support inexpensive/slow OBDII adapters.

This patch fixes the case in which "SEARCHING" is not shown after "0100",
due to slow response of cheap devices.

```
[obd.elm327] write: '0100\r'
[obd.elm327] read: b'SEARCHING...\r...
```

It should also fix the case in which the debug mode needs to be active:
in fact the debug logs might slow down the query timeout enough to be able
to catch the query answer.

Reference #205

Reference #200

Reference #187