### PR TITLE
Fix protocol auto detect on BT Elm 327

### DIFF
--- a/obd/elm327.py
+++ b/obd/elm327.py
@@ -241,7 +241,7 @@ class ELM327:
         """
 
         # -------------- try the ELM's auto protocol mode --------------
-        r = self.__send(b"ATSP0")
+        r = self.__send(b"ATSP0", delay=1)
 
         # -------------- 0100 (first command, SEARCH protocols) --------------
         r0100 = self.__send(b"0100", delay=1)


### PR DESCRIPTION
 #### Issues addressed
 Can't auto detect protocol on BT connection
 even if the elm devices detects the protocol
 successfully.

 Add delay after erasing stored protocols
 so the adapter can read the discover command

 #### Summary of testing
 Tested on an Mazda MX5.
 The protocol can be detected successfully
 on each run. Tested for about 10 times in a row.

Signed-off-by: Catalin Ghenea <catalin.ghenea@gmail.com>