### PR TITLE
Python 3.9+ support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["pyserial==3.*", "pint==0.7.*"],
+    install_requires=["pyserial==3.*", "pint==0.19.*"],
 )


### PR DESCRIPTION
python-OBD does not work with python 3.9+ because the old `pint` version uses deprecated collections API:

```python
ImportError: cannot import name 'MutableMapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
```

The issue was fixed in a newer `pint`.
This change, however, sets the minimum supported python version to 3.8, according to pint's README.