### PR TITLE
Fix test_populate_ecu_map test

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -74,4 +74,4 @@ def test_populate_ecu_map():
 
     # if no messages were received, then the map is empty
     p = SAE_J1850_PWM([])
-    assert len(p.ecu_map) == 0
+    assert p.ecu_map[p.TX_ID_ENGINE] == ECU.ENGINE


### PR DESCRIPTION
Originally, the ECU map was empty up on protocol initialization
https://github.com/brendan-w/python-OBD/blob/2c7828ebd103da4fe20b3292b5595a07b214b061/obd/protocols/protocol.py#L117

For some reason, tests checked the opposite and were "fixed" by @brendan-w in https://github.com/brendan-w/python-OBD/commit/2c7828ebd103da4fe20b3292b5595a07b214b061.

In 2020, @gmaniak authored https://github.com/brendan-w/python-OBD/commit/c14db6a3f13c3b0cf43dc6701d146cc92b08e5eb where they fixed an issue with ECU ID for legacy protocols by filling out the ECU map. This change broke the `test_populate_ecu_map` test which expected the map to be empty.

I am not an OBD/CAN expert, but looking at the above changes it seems that the @gmaniak change is valid, and the map must not be empty. I updated the test so that it expects `p.TX_ID_ENGINE` to be present in the map.