### PR TITLE
Update the python version range to 3.8-3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
-    check{36,38},
-    py{35,36,37,38},
+    py{38,39,310},
     coverage
 
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
     3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 usedevelop = true
@@ -17,18 +15,13 @@ setenv =
     COVERAGE_FILE={toxinidir}/.coverage_{envname}
 deps =
     pdbpp==0.9.6
-    pytest==3.10.1
-    pytest-cov==2.6.1
+    pytest==7.1.2
+    pytest-cov==3.0.0
 whitelist_externals =
     rm
 commands =
     rm -vf {toxinidir}/.coverage_{envname}
     pytest --cov-report= --cov=obd {posargs}
-
-[testenv:check36]
-basepython = python3.6
-skipsdist = true
-
 
 [testenv:coverage]
 skipsdist = true


### PR DESCRIPTION
pint=0.19.* is not available for python versions lower 3.8.
Updated the python version matrix used in CI to 3.8,3.9,3.10.
Also, updated `pytest` and `pytest-cov` versions as the older versions weren't compatible with py3.10.