### PR TITLE
Fix truncation of last character of VIN by modifying decode_encoded_string()

### DIFF
--- a/obd/__init__.py
+++ b/obd/__init__.py
@@ -46,11 +46,20 @@ from .OBDResponse import OBDResponse
 from .protocols import ECU
 from .utils import scan_serial, OBDStatus
 from .UnitsAndScaling import Unit
-
+import os
 import logging
 
+def getenv(key:str, default=0): return type(default)(os.getenv(key, default))
+
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
+DEBUG = getenv("DEBUG", 0)
+if DEBUG == 1:
+    logger.setLevel(logging.INFO)
+elif DEBUG == 2:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.WARNING)
+
 
 console_handler = logging.StreamHandler()  # sends output to stderr
 console_handler.setFormatter(logging.Formatter("[%(name)s] %(message)s"))

--- a/obd/__init__.py
+++ b/obd/__init__.py
@@ -46,20 +46,11 @@ from .OBDResponse import OBDResponse
 from .protocols import ECU
 from .utils import scan_serial, OBDStatus
 from .UnitsAndScaling import Unit
-import os
+
 import logging
 
-def getenv(key:str, default=0): return type(default)(os.getenv(key, default))
-
 logger = logging.getLogger(__name__)
-DEBUG = getenv("DEBUG", 0)
-if DEBUG == 1:
-    logger.setLevel(logging.INFO)
-elif DEBUG == 2:
-    logger.setLevel(logging.DEBUG)
-else:
-    logger.setLevel(logging.WARNING)
-
+logger.setLevel(logging.WARNING)
 
 console_handler = logging.StreamHandler()  # sends output to stderr
 console_handler.setFormatter(logging.Formatter("[%(name)s] %(message)s"))

--- a/obd/decoders.py
+++ b/obd/decoders.py
@@ -505,7 +505,8 @@ def decode_encoded_string(messages, length):
     # Encoded strings come in bundles of messages with leading null values to
     # pad out the string to the next full message size. We strip off the
     # leading null characters here and return the resulting string.
-    return d.strip().strip(b'\x00' b'\x01' b'\x02' b'\\x00' b'\\x01' b'\\x02')
+    decoded_string = d.strip().replace(b'\x00', b'').replace(b'\x01', b'').replace(b'\x02', b'').replace(b'\\x00', b'').replace(b'\\x01', b'').replace(b'\\x02', b'')
+    return decoded_string
 
 
 def cvn(messages):

--- a/obd/decoders.py
+++ b/obd/decoders.py
@@ -505,8 +505,7 @@ def decode_encoded_string(messages, length):
     # Encoded strings come in bundles of messages with leading null values to
     # pad out the string to the next full message size. We strip off the
     # leading null characters here and return the resulting string.
-    decoded_string = d.strip().replace(b'\x00', b'').replace(b'\x01', b'').replace(b'\x02', b'').replace(b'\\x00', b'').replace(b'\\x01', b'').replace(b'\\x02', b'')
-    return decoded_string
+    return d.strip().strip(b'\x00' b'\x01' b'\x02' b'\\x00' b'\\x01' b'\\x02')
 
 
 def cvn(messages):


### PR DESCRIPTION
When retrieving VIN via the following example code, I received 16 characters instead of the proper 17, and the trailing "0" in my VIN was truncated.
```
connection = obd.OBD()

cmd = obd.commands.VIN
response = connection.query(cmd)
print(response.value)
```

I modified decode_encoded_string() in decoders.py to use the .replace() function instead of .strip() to remove '\x00', '\x01', and '\x02', which resolved the issue in my testing.

