### PR TITLE
Fix escaped serial port label string for Windows

### DIFF
--- a/obd/utils.py
+++ b/obd/utils.py
@@ -174,7 +174,7 @@ def scan_serial():
         possible_ports += glob.glob("/dev/ttyUSB[0-9]*")
 
     elif sys.platform.startswith('win'):
-        possible_ports += ["\\.\COM%d" % i for i in range(256)]
+        possible_ports += [r"\\.\COM%d" % i for i in range(256)]
 
     elif sys.platform.startswith('darwin'):
         exclude = [


### PR DESCRIPTION
Without this fix, Python 3.13.1 yields this warning during "import odb":

    …/obd/utils.py:177: SyntaxWarning: invalid escape sequence '\C'

I'm not a Windows expert, but the correct naming convention seems to be described here:

https://support.microsoft.com/en-us/topic/howto-specify-serial-ports-larger-than-com9-db9078a5-b7b6-bf00-240f-f749ebfd913e