### PR TITLE
Removed duplicate licence declaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pint==0.24.*",
 ]
 license = "GPL-2.0-only"
-license-files = ["LICENSE"]
+# license-files = ["LICENSE"]
 
 [project.urls]
 Homepage = "https://github.com/brendan-w/python-OBD"


### PR DESCRIPTION
license-files = ["LICENSE"] is no longer valid under the [project] table in pyproject.toml — it was deprecated in PEP 621 and is now rejected by modern setuptools.